### PR TITLE
Improve timeout retries and serialize client requests

### DIFF
--- a/custom_components/franklinwh/coordinator.py
+++ b/custom_components/franklinwh/coordinator.py
@@ -24,6 +24,9 @@ _LOGGER = logging.getLogger(__name__)
 # Retry configuration for transient errors
 MAX_RETRIES = 2
 RETRY_DELAY = 3  # seconds
+UPDATE_RETRY_DELAYS = [5, 15]  # seconds between update retries
+SUCCESS_INTERVAL_JITTER = 5  # seconds (+/-) applied to successful polling interval
+EXTRA_FETCH_INTERVAL = timedelta(minutes=5)  # cadence for non-critical extra queries
 MAX_STALE_CYCLES = 10  # consecutive failed update cycles before marking unavailable
 
 # Adaptive polling/backoff (applies after an update fully fails, i.e. after retries)
@@ -88,6 +91,7 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
         self.battery_capacity: float = 15.0  # kWh - will be updated from device info
         self.tou_schedule: dict | None = None  # TOU rate schedule data
         self._last_tou_fetch: float = 0  # Timestamp of last TOU fetch
+        self._last_extra_fetch: float = 0  # Timestamp of last non-critical extra fetch
 
         # Adaptive polling/backoff state
         self._consecutive_update_failures: int = 0
@@ -108,7 +112,9 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
         # is set to at the end of the update cycle.
         if self.update_interval != new_interval:
             self.update_interval = new_interval
-            _LOGGER.info("Polling interval set to %s (%s)", new_interval, reason)
+            (
+                _LOGGER.debug if reason.startswith("jitter") else _LOGGER.info
+            )("Polling interval set to %s (%s)", new_interval, reason)
 
     def _compute_backoff_interval(self) -> timedelta:
         """Compute next polling interval using exponential backoff + jitter."""
@@ -126,6 +132,35 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
         exp_seconds = max(base_seconds, min(exp_seconds, max_seconds))
         return timedelta(seconds=exp_seconds)
 
+    def _compute_jittered_success_interval(self) -> timedelta:
+        """Compute a slightly jittered polling interval for successful cycles.
+
+        This helps de-phase polling from periodic backend/gateway hiccups.
+        """
+        base_seconds = UPDATE_INTERVAL.total_seconds()
+        jitter = random.uniform(-SUCCESS_INTERVAL_JITTER, SUCCESS_INTERVAL_JITTER)
+        seconds = base_seconds + jitter
+        # Never go below 10s to avoid hammering.
+        seconds = max(10.0, seconds)
+        return timedelta(seconds=seconds)
+
+    async def _fetch_extra_data_if_needed(self) -> None:
+        """Fetch non-critical extra data on a slower cadence.
+
+        This reduces total command volume (and therefore the odds of hitting the
+        Franklin cloud/gateway "Device response timed out" windows).
+        """
+        import time
+
+        now = time.time()
+        if self._last_extra_fetch == 0 or (now - self._last_extra_fetch) >= EXTRA_FETCH_INTERVAL.total_seconds():
+            self._last_extra_fetch = now
+
+            # These calls are explicitly non-fatal; each method handles its own errors.
+            await self._fetch_current_mode()
+            await self._fetch_charging_limited()
+            await self._fetch_ambient_temp()
+
     async def _async_update_data(self) -> Stats:
         """Fetch data from FranklinWH with retry logic."""
         # Ensure client is initialized (first time only)
@@ -140,14 +175,8 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
                 # Fetch stats - library method is async, await it directly
                 stats = await _async_resolve(self._client.get_stats())
 
-                # Fetch current mode with same retry logic as stats
-                await self._fetch_current_mode()
-
-                # Fetch charging power limited status
-                await self._fetch_charging_limited()
-
-                # Fetch ambient temperature from _status endpoint
-                await self._fetch_ambient_temp()
+                # Fetch non-critical extras on a slower cadence to reduce request volume
+                await self._fetch_extra_data_if_needed()
 
                 # Fetch TOU schedule once per hour (don't fail if it errors)
                 await self._fetch_tou_schedule_if_needed()
@@ -159,7 +188,10 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
                 # Reset adaptive backoff on success
                 if self._consecutive_update_failures > 0:
                     self._consecutive_update_failures = 0
-                    self._set_update_interval(self._base_update_interval, "recovered")
+
+                # Apply small jitter on successful cycles to de-phase polling
+                jittered_interval = self._compute_jittered_success_interval()
+                self._set_update_interval(jittered_interval, "jitter")
 
                 return stats
 
@@ -168,14 +200,16 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
 
                 # If we have retries left, wait and try again
                 if attempt < MAX_RETRIES:
+                    idx = min(attempt, len(UPDATE_RETRY_DELAYS) - 1)
+                    delay = UPDATE_RETRY_DELAYS[idx]
                     _LOGGER.warning(
                         "Transient error fetching data (attempt %d/%d): %s. Retrying in %d seconds...",
                         attempt + 1,
                         MAX_RETRIES + 1,
                         err,
-                        RETRY_DELAY,
+                        delay,
                     )
-                    await asyncio.sleep(RETRY_DELAY)
+                    await asyncio.sleep(delay)
                     continue
 
                 # Out of retries, apply adaptive backoff and either return cached data or fail the update

--- a/custom_components/franklinwh/coordinator.py
+++ b/custom_components/franklinwh/coordinator.py
@@ -24,9 +24,12 @@ _LOGGER = logging.getLogger(__name__)
 # Retry configuration for transient errors
 MAX_RETRIES = 2
 RETRY_DELAY = 3  # seconds
+MAX_STALE_CYCLES = 10  # consecutive failed update cycles before marking unavailable
+
+# Adaptive polling/backoff (applies after an update fully fails, i.e. after retries)
 MAX_BACKOFF_INTERVAL = timedelta(minutes=5)
 BACKOFF_FACTOR = 2.0
-BACKOFF_JITTER_PCT = 0.10
+BACKOFF_JITTER_PCT = 0.10  # +/- 10%
 
 # Map numeric mode values from API to our mode keys
 # The franklinwh library only knows about standard modes: 9322, 9323, 9324
@@ -175,13 +178,29 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
                     await asyncio.sleep(RETRY_DELAY)
                     continue
 
-                # Out of retries, apply adaptive backoff and fail the update
+                # Out of retries, apply adaptive backoff and either return cached data or fail the update
                 self._consecutive_update_failures += 1
                 backoff_interval = self._compute_backoff_interval()
                 self._set_update_interval(
                     backoff_interval,
                     f"backoff after {self._consecutive_update_failures} failed update(s)",
                 )
+
+                # If we have cached data, keep entities available by returning stale values.
+                # After MAX_STALE_CYCLES consecutive failed update cycles, mark unavailable.
+                if self.data is not None:
+                    if self._consecutive_update_failures < MAX_STALE_CYCLES:
+                        _LOGGER.warning(
+                            "Gateway refresh timed out after %d attempts; keeping last known values (failure count=%d)",
+                            MAX_RETRIES + 1,
+                            self._consecutive_update_failures,
+                        )
+                        return self.data
+
+                    _LOGGER.error(
+                        "Exceeded max stale cycles (%d); marking unavailable",
+                        MAX_STALE_CYCLES,
+                    )
 
                 _LOGGER.error("Failed to fetch data after %d attempts: %s", MAX_RETRIES + 1, err)
                 raise UpdateFailed(f"Failed after {MAX_RETRIES + 1} attempts: {err}") from err

--- a/custom_components/franklinwh/coordinator.py
+++ b/custom_components/franklinwh/coordinator.py
@@ -5,6 +5,7 @@ import asyncio
 from datetime import timedelta
 import logging
 import inspect
+import random
 from typing import Any
 
 import httpx
@@ -23,6 +24,9 @@ _LOGGER = logging.getLogger(__name__)
 # Retry configuration for transient errors
 MAX_RETRIES = 2
 RETRY_DELAY = 3  # seconds
+MAX_BACKOFF_INTERVAL = timedelta(minutes=5)
+BACKOFF_FACTOR = 2.0
+BACKOFF_JITTER_PCT = 0.10
 
 # Map numeric mode values from API to our mode keys
 # The franklinwh library only knows about standard modes: 9322, 9323, 9324
@@ -82,6 +86,11 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
         self.tou_schedule: dict | None = None  # TOU rate schedule data
         self._last_tou_fetch: float = 0  # Timestamp of last TOU fetch
 
+        # Adaptive polling/backoff state
+        self._consecutive_update_failures: int = 0
+        self._base_update_interval: timedelta = UPDATE_INTERVAL
+        self._max_backoff_interval: timedelta = MAX_BACKOFF_INTERVAL
+
     async def _ensure_client(self) -> None:
         """Ensure client is initialized."""
         if self._client is None:
@@ -89,6 +98,30 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
             self._client = await self.hass.async_add_executor_job(
                 Client, self._token_fetcher, self.gateway_id
             )
+
+    def _set_update_interval(self, new_interval: timedelta, reason: str) -> None:
+        """Update coordinator polling interval (adaptive backoff)."""
+        # DataUpdateCoordinator schedules the next refresh using whatever update_interval
+        # is set to at the end of the update cycle.
+        if self.update_interval != new_interval:
+            self.update_interval = new_interval
+            _LOGGER.info("Polling interval set to %s (%s)", new_interval, reason)
+
+    def _compute_backoff_interval(self) -> timedelta:
+        """Compute next polling interval using exponential backoff + jitter."""
+        base_seconds = self._base_update_interval.total_seconds()
+        max_seconds = self._max_backoff_interval.total_seconds()
+
+        # First failed update => base * factor, second => base * factor^2, third => base * factor^3, ...
+        exp_seconds = base_seconds * (BACKOFF_FACTOR ** self._consecutive_update_failures)
+        exp_seconds = min(exp_seconds, max_seconds)
+
+        jitter = exp_seconds * BACKOFF_JITTER_PCT
+        exp_seconds = exp_seconds + random.uniform(-jitter, jitter)
+
+        # Clamp and ensure we never go below base
+        exp_seconds = max(base_seconds, min(exp_seconds, max_seconds))
+        return timedelta(seconds=exp_seconds)
 
     async def _async_update_data(self) -> Stats:
         """Fetch data from FranklinWH with retry logic."""
@@ -120,6 +153,11 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
                 if attempt > 0:
                     _LOGGER.info("Successfully fetched data after %d retry(ies)", attempt)
 
+                # Reset adaptive backoff on success
+                if self._consecutive_update_failures > 0:
+                    self._consecutive_update_failures = 0
+                    self._set_update_interval(self._base_update_interval, "recovered")
+
                 return stats
 
             except (DeviceTimeoutException, GatewayOfflineException, httpx.ReadTimeout, httpx.ConnectTimeout) as err:
@@ -137,7 +175,14 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
                     await asyncio.sleep(RETRY_DELAY)
                     continue
 
-                # Out of retries, fail the update
+                # Out of retries, apply adaptive backoff and fail the update
+                self._consecutive_update_failures += 1
+                backoff_interval = self._compute_backoff_interval()
+                self._set_update_interval(
+                    backoff_interval,
+                    f"backoff after {self._consecutive_update_failures} failed update(s)",
+                )
+
                 _LOGGER.error("Failed to fetch data after %d attempts: %s", MAX_RETRIES + 1, err)
                 raise UpdateFailed(f"Failed after {MAX_RETRIES + 1} attempts: {err}") from err
 

--- a/custom_components/franklinwh/coordinator.py
+++ b/custom_components/franklinwh/coordinator.py
@@ -24,10 +24,13 @@ _LOGGER = logging.getLogger(__name__)
 # Retry configuration for transient errors
 MAX_RETRIES = 2
 RETRY_DELAY = 3  # seconds
+
+# Per-attempt retry delays for the main stats refresh
 UPDATE_RETRY_DELAYS = [5, 15]  # seconds between update retries
-SUCCESS_INTERVAL_JITTER = 5  # seconds (+/-) applied to successful polling interval
-EXTRA_FETCH_INTERVAL = timedelta(minutes=5)  # cadence for non-critical extra queries
-MAX_STALE_CYCLES = 10  # consecutive failed update cycles before marking unavailable
+
+# Optional safety knob: number of consecutive failed update cycles to tolerate
+# while returning cached data (prevents entities flipping to "unavailable").
+MAX_STALE_CYCLES = 10
 
 # Adaptive polling/backoff (applies after an update fully fails, i.e. after retries)
 MAX_BACKOFF_INTERVAL = timedelta(minutes=5)
@@ -85,13 +88,15 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
         self._token_fetcher = TokenFetcher(email, password)
         # Client will be created in first update to avoid blocking I/O in __init__
         self._client: Client | None = None
+        # Serialize all franklinwh client network calls to avoid overlapping
+        # requests (which can trigger token/auth edge cases).
+        self._client_lock = asyncio.Lock()
         self.current_mode: str | None = None
         self.ambient_temp: float | None = None
         self.charging_power_limited: bool | None = None
         self.battery_capacity: float = 15.0  # kWh - will be updated from device info
         self.tou_schedule: dict | None = None  # TOU rate schedule data
         self._last_tou_fetch: float = 0  # Timestamp of last TOU fetch
-        self._last_extra_fetch: float = 0  # Timestamp of last non-critical extra fetch
 
         # Adaptive polling/backoff state
         self._consecutive_update_failures: int = 0
@@ -108,21 +113,27 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
 
     def _set_update_interval(self, new_interval: timedelta, reason: str) -> None:
         """Update coordinator polling interval (adaptive backoff)."""
-        # DataUpdateCoordinator schedules the next refresh using whatever update_interval
-        # is set to at the end of the update cycle.
+        # Prefer DataUpdateCoordinator's rescheduler if available so the new
+        # interval takes effect immediately (not just after a restart).
         if self.update_interval != new_interval:
-            self.update_interval = new_interval
-            (
-                _LOGGER.debug if reason.startswith("jitter") else _LOGGER.info
-            )("Polling interval set to %s (%s)", new_interval, reason)
+            if hasattr(self, "async_set_update_interval"):
+                try:
+                    self.async_set_update_interval(new_interval)
+                except Exception:
+                    # Fall back to simple assignment if HA's API differs.
+                    self.update_interval = new_interval
+            else:
+                self.update_interval = new_interval
+
+            _LOGGER.info("Polling interval set to %s (%s)", new_interval, reason)
 
     def _compute_backoff_interval(self) -> timedelta:
         """Compute next polling interval using exponential backoff + jitter."""
         base_seconds = self._base_update_interval.total_seconds()
         max_seconds = self._max_backoff_interval.total_seconds()
 
-        # First failed update => base * factor, second => base * factor^2, third => base * factor^3, ...
-        exp_seconds = base_seconds * (BACKOFF_FACTOR ** self._consecutive_update_failures)
+        # First failed update => base * 1, second => base * 2, third => base * 4, ...
+        exp_seconds = base_seconds * (BACKOFF_FACTOR ** max(0, self._consecutive_update_failures - 1))
         exp_seconds = min(exp_seconds, max_seconds)
 
         jitter = exp_seconds * BACKOFF_JITTER_PCT
@@ -131,35 +142,6 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
         # Clamp and ensure we never go below base
         exp_seconds = max(base_seconds, min(exp_seconds, max_seconds))
         return timedelta(seconds=exp_seconds)
-
-    def _compute_jittered_success_interval(self) -> timedelta:
-        """Compute a slightly jittered polling interval for successful cycles.
-
-        This helps de-phase polling from periodic backend/gateway hiccups.
-        """
-        base_seconds = UPDATE_INTERVAL.total_seconds()
-        jitter = random.uniform(-SUCCESS_INTERVAL_JITTER, SUCCESS_INTERVAL_JITTER)
-        seconds = base_seconds + jitter
-        # Never go below 10s to avoid hammering.
-        seconds = max(10.0, seconds)
-        return timedelta(seconds=seconds)
-
-    async def _fetch_extra_data_if_needed(self) -> None:
-        """Fetch non-critical extra data on a slower cadence.
-
-        This reduces total command volume (and therefore the odds of hitting the
-        Franklin cloud/gateway "Device response timed out" windows).
-        """
-        import time
-
-        now = time.time()
-        if self._last_extra_fetch == 0 or (now - self._last_extra_fetch) >= EXTRA_FETCH_INTERVAL.total_seconds():
-            self._last_extra_fetch = now
-
-            # These calls are explicitly non-fatal; each method handles its own errors.
-            await self._fetch_current_mode()
-            await self._fetch_charging_limited()
-            await self._fetch_ambient_temp()
 
     async def _async_update_data(self) -> Stats:
         """Fetch data from FranklinWH with retry logic."""
@@ -173,10 +155,17 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
         for attempt in range(MAX_RETRIES + 1):
             try:
                 # Fetch stats - library method is async, await it directly
-                stats = await _async_resolve(self._client.get_stats())
+                async with self._client_lock:
+                    stats = await _async_resolve(self._client.get_stats())
 
-                # Fetch non-critical extras on a slower cadence to reduce request volume
-                await self._fetch_extra_data_if_needed()
+                # Fetch current mode with same retry logic as stats
+                await self._fetch_current_mode()
+
+                # Fetch charging power limited status
+                await self._fetch_charging_limited()
+
+                # Fetch ambient temperature from _status endpoint
+                await self._fetch_ambient_temp()
 
                 # Fetch TOU schedule once per hour (don't fail if it errors)
                 await self._fetch_tou_schedule_if_needed()
@@ -188,10 +177,7 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
                 # Reset adaptive backoff on success
                 if self._consecutive_update_failures > 0:
                     self._consecutive_update_failures = 0
-
-                # Apply small jitter on successful cycles to de-phase polling
-                jittered_interval = self._compute_jittered_success_interval()
-                self._set_update_interval(jittered_interval, "jitter")
+                    self._set_update_interval(self._base_update_interval, "recovered")
 
                 return stats
 
@@ -223,7 +209,7 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
                 # If we have cached data, keep entities available by returning stale values.
                 # After MAX_STALE_CYCLES consecutive failed update cycles, mark unavailable.
                 if self.data is not None:
-                    if self._consecutive_update_failures < MAX_STALE_CYCLES:
+                    if self._consecutive_update_failures <= MAX_STALE_CYCLES:
                         _LOGGER.warning(
                             "Gateway refresh timed out after %d attempts; keeping last known values (failure count=%d)",
                             MAX_RETRIES + 1,
@@ -260,7 +246,8 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
                 # Call _switch_status() directly to get raw mode value
                 # This avoids the KeyError that get_mode() raises for unknown modes
                 # Note: _switch_status might be async, await it directly
-                status = await _async_resolve(self._client._switch_status())
+                async with self._client_lock:
+                    status = await _async_resolve(self._client._switch_status())
 
                 if status and "runingMode" in status:
                     raw_mode = status["runingMode"]
@@ -320,7 +307,8 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
                 return
 
             # Call _status() to get raw status data including t_amb
-            status = await _async_resolve(self._client._status())
+            async with self._client_lock:
+                status = await _async_resolve(self._client._status())
 
             if status and "t_amb" in status:
                 self.ambient_temp = status["t_amb"]
@@ -345,7 +333,8 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
                 201,
                 {"gatewayId": self.gateway_id}
             )
-            response = await _async_resolve(self._client._mqtt_send(payload))
+            async with self._client_lock:
+                response = await _async_resolve(self._client._mqtt_send(payload))
 
             if response and "result" in response:
                 result = response["result"]
@@ -382,7 +371,8 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
             # This endpoint doesn't require gatewayId in the payload
             url = self._client.url_base + "hes-gateway/terminal/tou/getTouDispatchDetail"
             _LOGGER.info("Fetching TOU schedule from API...")
-            response = await _async_resolve(self._client._get(url, None))
+            async with self._client_lock:
+                response = await _async_resolve(self._client._get(url, None))
 
             if response and "result" in response:
                 self.tou_schedule = response["result"]
@@ -640,10 +630,11 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
 
         for attempt in range(MAX_RETRIES + 1):
             try:
-                result = await self.hass.async_add_executor_job(
-                    self._client.set_mode, mode
-                )
-                await _async_resolve(result)
+                async with self._client_lock:
+                    result = await self.hass.async_add_executor_job(
+                        self._client.set_mode, mode
+                    )
+                    await _async_resolve(result)
                 # Success! Request immediate refresh to get updated data
                 await self.async_request_refresh()
 
@@ -680,10 +671,11 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
 
         for attempt in range(MAX_RETRIES + 1):
             try:
-                result = await self.hass.async_add_executor_job(
-                    self._client.set_smart_switch_state, switch_id, state
-                )
-                await _async_resolve(result)
+                async with self._client_lock:
+                    result = await self.hass.async_add_executor_job(
+                        self._client.set_smart_switch_state, switch_id, state
+                    )
+                    await _async_resolve(result)
                 # Success! Request immediate refresh
                 await self.async_request_refresh()
 


### PR DESCRIPTION
This PR reduces transient “Device response timed out” failures and mitigates occasional auth/token edge cases.

* Fixes #4 (improve resilience to intermittent FranklinWH API timeouts / availability flaps)
* Adjust update retry delays to a simple staged approach: retry with 5s then 15s delays (3 total attempts). Early testing shows more recoveries on the 2nd attempt and fewer full update failures.
* Serialize FranklinWH client calls with a single async lock to avoid overlapping requests (helps prevent token/auth edge cases observed occasionally in logs).
* Keep entities available on transient failures by returning cached coordinator data after retries fail for a bounded number of cycles (`MAX_STALE_CYCLES`), while still logging each failed refresh (so failures remain visible in logs).
* Observed rare cases where all 3 attempts time out; cached fallback prevents entity availability flaps while logging the event.

### Testing

Testing for several hours with debug logs enabled mostly shows successful recovery on retry (e.g., attempt 2/3 with 15s delay). In rare situations where the 3rd retry fails, cached data is returned, preventing "unavailable" events (up to `MAX_STALE_CYCLES` times).