### PR TITLE
Fix: Add custom mode values observed on an aHub installation

### DIFF
--- a/custom_components/franklinwh/coordinator.py
+++ b/custom_components/franklinwh/coordinator.py
@@ -49,6 +49,10 @@ MODE_VALUE_MAP = {
     113349: MODE_TIME_OF_USE,       # E-TOU-C (customized Time of Use)
     117082: MODE_SELF_CONSUMPTION,  # Customized Self Consumption
     46540: MODE_BACKUP,              # Customized Emergency Backup
+    # Customized modes (observed on user's aHub)
+    161804: MODE_TIME_OF_USE,       # E-TOU-C (customized Time of Use)
+    130849: MODE_SELF_CONSUMPTION,  # Customized Self Consumption
+    111374: MODE_BACKUP,            # Customized Emergency Backup
 }
 
 


### PR DESCRIPTION
The `MODE_VALUE_MAP` in `coordinator.py` includes standard mode values and a set of customized values, believed to have been observed on aGate installations. Without a matching entry in this map, an installation falls through to the unknown-mode fallback, which silently defaults the mode sensor to Time of Use regardless of the device's actual operating mode.

This adds three additional mappings observed on a single aHub installation. It is unclear whether these values are specific to aHub hardware or reflect some other variation (firmware version, regional configuration, etc.).

| Value | Mode |
|-------|------|
| 161804 | Time of Use |
| 130849 | Self Consumption |
| 111374 | Emergency Backup |

These are offered as a starting point. Confirmation from other aHub users would help determine whether these values are consistent across aHub installations.