### PR TITLE
Map runingMode=21312 to self_consumption + fail-loud on unknown values

### DIFF
--- a/custom_components/franklinwh/coordinator.py
+++ b/custom_components/franklinwh/coordinator.py
@@ -53,6 +53,8 @@ MODE_VALUE_MAP = {
     161804: MODE_TIME_OF_USE,       # E-TOU-C (customized Time of Use)
     130849: MODE_SELF_CONSUMPTION,  # Customized Self Consumption
     111374: MODE_BACKUP,            # Customized Emergency Backup
+    # Additional customized mode (observed on aGate2; see issue #6)
+    21312: MODE_SELF_CONSUMPTION,
 }
 
 
@@ -261,13 +263,17 @@ class FranklinWHCoordinator(DataUpdateCoordinator[Stats]):
                         self.current_mode = MODE_VALUE_MAP[raw_mode]
                         _LOGGER.debug("Mapped mode %s to %s", raw_mode, self.current_mode)
                     else:
-                        # Unknown mode - default to time_of_use as a safe fallback
+                        # Unknown mode - surface as "unknown" rather than silently
+                        # masquerading as Time-of-Use. TOU is a real operational
+                        # mode, so a silent fallback hides mis-mapping for weeks.
+                        # See issue #6 — leaving current_mode=None makes any new
+                        # unmapped runingMode value immediately visible in HA.
                         _LOGGER.warning(
-                            "Unknown mode value %s from gateway. Treating as time_of_use. "
+                            "Unknown mode value %s from gateway. Setting state to unknown. "
                             "Please report this to https://github.com/richo/franklinwh-python/issues",
                             raw_mode
                         )
-                        self.current_mode = MODE_TIME_OF_USE
+                        self.current_mode = None
 
                     if attempt > 0:
                         _LOGGER.info("Successfully fetched mode after %d retry(ies)", attempt)


### PR DESCRIPTION
## Problem

The gateway returns raw `runingMode: 21312` on a residential aGate2 install, but this value is not in `MODE_VALUE_MAP`. The current unknown-mode fallback silently maps any unknown value to `MODE_TIME_OF_USE`, which masked the mis-reporting for weeks — the integration reported "Time of Use" in HA while the FranklinWH mobile app correctly showed "Self Consumption". The only signal was a single `WARNING` log line that's easy to miss until automations or the energy dashboard surface the wrong behaviour.

The exact firmware that introduced 21312 isn't pinned down — it appears to be a recent (early/mid-2026) firmware rolling out to aGate2 hardware.

Refs #6.

## Changes

Two small, independent changes in `coordinator.py`:

1. **Add `21312: MODE_SELF_CONSUMPTION` to `MODE_VALUE_MAP`.** Verified against the gateway state visible in the FranklinWH mobile app while the integration was reporting Time-of-Use — flipping the mode in the app to Backup / TOU and back confirmed 21312 is the self-consumption value on this gateway.

2. **Change the unknown-mode fallback from `MODE_TIME_OF_USE` to `None`.** This is defensive. TOU is a real operational mode, so users have no way to detect mis-mapping just by looking at the entity state. Returning `None` makes the entity show `unknown` in HA, which surfaces mis-mapping immediately the next time a gateway emits an unmapped raw value.

## Testing

- Tested in production on a residential aGate2 install for ~30 min after the patch was applied. Mode reporting now tracks the FranklinWH app correctly across mode flips (Self Consumption / TOU / Backup) and matches the raw `runingMode` returned by `_switch_status()`.
- No regressions observed — the existing mapped values continue to resolve via the map; the fallback path is only exercised for genuinely unknown values, where the new behaviour is strictly more honest.

## Notes for maintainers

- The two changes are independent and pair naturally, but happy to split into two commits / two PRs if that's easier to review. The 21312 addition is a one-liner; the `None` fallback is the behavioural change worth more discussion.
- The warning log line is unchanged in intent — only the trailing "Treating as time_of_use" wording is updated to "Setting state to unknown" to match the new behaviour.